### PR TITLE
OC-123: add recordTestResults option for clover:setup and clover:instr

### DIFF
--- a/src/main/java/com/atlassian/maven/plugin/clover/internal/AbstractCloverInstrumentMojo.java
+++ b/src/main/java/com/atlassian/maven/plugin/clover/internal/AbstractCloverInstrumentMojo.java
@@ -222,6 +222,14 @@ public abstract class AbstractCloverInstrumentMojo extends AbstractCloverMojo im
     protected Set<MethodWithMetricsContext> methodWithMetricsContexts = new HashSet<MethodWithMetricsContext>();
 
     /**
+     * If set to 'false', test results will not be recorded; instead, results can be added via the
+     * &lt;testResults&gt; fileset at report time. Useful when a test uses a custom
+     * Rule expecting an exception, which OpenClover cannot recognize.
+     */
+    @Parameter(property = "maven.clover.recordTestResults", defaultValue = "true")
+    protected boolean recordTestResults = true;
+
+    /**
      * <p>Try to protect your build from installing instrumented artifacts into local ~/.m2 cache
      * or deploying them to a binaries repository. If this option is enabled, Clover will fail a build whenever
      * it detects that 'install' or 'deploy' phase is about to be called. It will also fail a build if
@@ -479,6 +487,11 @@ public abstract class AbstractCloverInstrumentMojo extends AbstractCloverMojo im
     @Override
     public TestSources getTestSources() {
         return testSources;
+    }
+
+    @Override
+    public boolean isRecordTestResults() {
+        return recordTestResults;
     }
 
     private static final String PROTECTION_ENABLED_MSG = "Clover's repository pollution protection is enabled. ";

--- a/src/main/java/com/atlassian/maven/plugin/clover/internal/CompilerConfiguration.java
+++ b/src/main/java/com/atlassian/maven/plugin/clover/internal/CompilerConfiguration.java
@@ -42,4 +42,6 @@ public interface CompilerConfiguration extends CloverConfiguration {
     boolean isCopyExcludedFiles();
 
     TestSources getTestSources();
+
+    boolean isRecordTestResults();
 }

--- a/src/main/java/com/atlassian/maven/plugin/clover/internal/instrumentation/AbstractInstrumenter.java
+++ b/src/main/java/com/atlassian/maven/plugin/clover/internal/instrumentation/AbstractInstrumenter.java
@@ -276,6 +276,11 @@ public abstract class AbstractInstrumenter {
             }
         }
 
+        if (getConfiguration().isRecordTestResults()) {
+            parameters.add("--recordTestResults");
+            parameters.add(Boolean.toString(getConfiguration().isRecordTestResults()));
+        }
+
         // custom contexts
         addCustomContexts(parameters, getConfiguration().getMethodContexts().entrySet(), "-mc");
         addCustomContexts(parameters, getConfiguration().getStatementContexts().entrySet(), "-sc");


### PR DESCRIPTION
The same like <clover-setup> and <clover-instr> Ant tasks.